### PR TITLE
Adjust dynamic search version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "dachcom-digital/dynamic-search": "^0.6",
+        "dachcom-digital/dynamic-search": "^0.7",
         "pimcore/pimcore": "^5.8.0 | ^6.3",
         "vdb/php-spider": "^0.4"
     },


### PR DESCRIPTION
Composer can otherwise not find an installable set of packages if dachcom-digital/dynamic-search 0.7 is being used:

  Problem 1
    - Installation request for dachcom-digital/dynamic-search-data-provider-crawler ~0.6.0 -> satisfiable by dachcom-digital/dynamic-search-data-provider-crawler[v0.6.0].
    - dachcom-digital/dynamic-search-data-provider-crawler v0.6.0 requires dachcom-digital/dynamic-search ^0.6 -> satisfiable by dachcom-digital/dynamic-search[v0.6.0, v0.6.1, v0.6.2] but these conflict with your requirements or minimum-stability.
