### PR TITLE
Fixed type declaration

### DIFF
--- a/src/DsWebCrawlerBundle/Filter/FilterPersistor.php
+++ b/src/DsWebCrawlerBundle/Filter/FilterPersistor.php
@@ -62,7 +62,7 @@ class FilterPersistor
         }
     }
 
-    private function openFile(string $file, int $mode): mixed
+    private function openFile(string $file, string $mode): mixed
     {
         return @fopen($file, $mode);
     }


### PR DESCRIPTION
$mode must be string as it is string in fopen and calls also provide a string.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none

Fixed type declaration to fit function calls.