### PR TITLE
Fix greediness of regex style clean in TextExtractor.php

### DIFF
--- a/src/Resource/FieldTransformer/Html/TextExtractor.php
+++ b/src/Resource/FieldTransformer/Html/TextExtractor.php
@@ -102,7 +102,7 @@ class TextExtractor implements FieldTransformerInterface
     {
         $text = preg_replace([
             '@(<script[^>]*?>.*?</script>)@si', // Strip out javascript
-            '@<style[^>]*?>.*?</style>@siU', // Strip style tags properly
+            '@<style[^>]*?>.*?</style>@si', // Strip style tags properly
             '@<![\s\S]*?--[ \t\n\r]*>@' // Strip multi-line comments including CDATA
         ], '', $html);
 


### PR DESCRIPTION
currently it cuts too much because of U combined with ? in regex

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | yes/no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
